### PR TITLE
Update AppVeyor CI to use librdkafka 1.6.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ image: Visual Studio 2017
 clone_folder: C:\projects\php_simple_kafka_client
 environment:
   BIN_SDK_VER: 2.2.0
-  DEP: librdkafka-1.5.3
+  DEP: librdkafka-1.6.2
   matrix:
     - PHP_VER: 7.4
       TS: 0

--- a/.appveyor/package.ps1
+++ b/.appveyor/package.ps1
@@ -28,7 +28,6 @@ $files = @(
     "C:\projects\php_simple_kafka_client\LICENSE",
     "C:\projects\php_simple_kafka_client\README.md",
     "C:\build-cache\deps\bin\librdkafka.dll",
-    "C:\build-cache\deps\bin\librdkafka.pdb",
     "C:\build-cache\deps\LICENSE.LIBRDKAFKA"
 )
 Compress-Archive $files "C:\$zip_bname"


### PR DESCRIPTION
librdkafka 1.6.2 is now ready to use for Windows. If all is good, I'll replace 1.5.3 with 1.6.2 for the PECL builds as well.